### PR TITLE
Remove tests that fail on 32 bit

### DIFF
--- a/math-functions.cabal
+++ b/math-functions.cabal
@@ -24,8 +24,14 @@ extra-source-files:
   tests/Tests/*.hs
   tests/Tests/SpecFunctions/gen.py
 
+flag sse2
+  description: Does the target support SSE2?
+  default: True
+
 library
   ghc-options:          -Wall
+  if arch(i386) && flag(sse2)
+    ghc-options:        -msse2
   build-depends:        base >=3 && <5,
                         deepseq,
                         erf >= 2,
@@ -42,6 +48,9 @@ library
 test-suite tests
   type:           exitcode-stdio-1.0
   ghc-options:    -Wall -threaded
+  if arch(i386)
+    -- The Sum tests require SSE2 on i686 to pass (because of excess precision)
+    ghc-options:  -msse2
   hs-source-dirs: tests
   main-is:        tests.hs
   other-modules:


### PR DESCRIPTION
I wasn't able to determine what's happening here; the commented out tests fail _only_ on 32 bit systems and _only_ if compiled with `-O`. What's even stranger is that `ghc -O` produces _exactly the same_ core on 32 and 64 bit, but it fails only of 32 bit.

This looks suspiciously like a GHC bug (since optimized build produces different results from non-optimized). I will investigate this more and file a GHC bug if this is the case, but I suggest removing these test cases meanwhile.
